### PR TITLE
Move bluepot URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ High-Interaction Honeypots
     - [Netbait](http://netbaitinc.com/)
 
 - Server (Bluetooth)
-    - [Bluepot](http://andrewmichaelsmith.com/bluepot/)
+    - [Bluepot](https://github.com/andrewmichaelsmith/bluepot)
 
 - Dynamic analysis of Android apps
     - [Droidbox](https://code.google.com/p/droidbox/)


### PR DESCRIPTION
I've got rid of the gh-pages setup because I keep forgetting to maintain it.