### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Discover more awesome lists at [sindresorhus/awesome](https://github.com/sindres
     - [HonSSH](https://github.com/tnich/honssh)
 
 - Anti-Cheat
-    - [Minecraft honeypot](http://mods.curse.com/bukkit-plugins/minecraft/honeypot)
+    - [Minecraft honeypot](https://mods.curse.com/bukkit-plugins/minecraft/honeypot)
 
 - behavioral analysis tool for win32
     - [Capture BAT](https://www.honeynet.org/node/315)
@@ -305,7 +305,7 @@ Discover more awesome lists at [sindresorhus/awesome](https://github.com/sindres
 
 - Spamtrap
     - [Mailoney](https://github.com/awhitehatter/mailoney) - SMTP honeypot, Open Relay, Cred Harvester written in python.
-    - [Spampot.py](https://woozle.org/%7Eneale/src/python/spampot.py)
+    - [Spampot.py](https://woozle.org/neale/src/python/spampot.py)
     - [Spamhole](http://www.spamhole.net/)
     - [spamd](http://man.openbsd.org/cgi-bin/man.cgi?query=spamd%26apropos=0%26sektion=0%26manpath=OpenBSD+Current%26arch=i386%26format=html)
     - [Mail::SMTP::Honeypot](http://search.cpan.org/~miker/Mail-SMTP-Honeypot-0.11/Honeypot.pm) - perl module that appears to provide the functionality of a standard SMTP server
@@ -313,7 +313,7 @@ Discover more awesome lists at [sindresorhus/awesome](https://github.com/sindres
     - [SpamHAT](https://github.com/miguelraulb/spamhat) - Spam Honeypot Tool
     - [SendMeSpamIDS.py](https://github.com/johestephan/SendMeSpamIDS.py) Simple SMTP fetch all IDS and analyzer
     - [Shiva](https://github.com/shiva-spampot/shiva) - Spam Honeypot with Intelligent Virtual Analyzer
-        - [Shiva The Spam Honeypot Tips And Tricks For Getting It Up And Running](https://www.pentestpartners.com/security-blog/shiva-the-spam-honeypot-tips-and-tricks-for-getting-it-up-and-running)
+        - [Shiva The Spam Honeypot Tips And Tricks For Getting It Up And Running](https://www.pentestpartners.com/security-blog/shiva-the-spam-honeypot-tips-and-tricks-for-getting-it-up-and-running/)
 
 - Distributed spam tracking
     - [Project Honeypot](https://www.projecthoneypot.org)


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://mods.curse.com/bukkit-plugins/minecraft/honeypot | https://mods.curse.com/bukkit-plugins/minecraft/honeypot 


### Other Corrected URLs 
Was | Now 
--- | --- 
https://woozle.org/%7Eneale/src/python/spampot.py | https://woozle.org/neale/src/python/spampot.py 
https://www.pentestpartners.com/security-blog/shiva-the-spam-honeypot-tips-and-tricks-for-getting-it-up-and-running | https://www.pentestpartners.com/security-blog/shiva-the-spam-honeypot-tips-and-tricks-for-getting-it-up-and-running/ 
