### PR TITLE
Add Krawl to web honeypots list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Discover more awesome lists at [sindresorhus/awesome](https://github.com/sindres
   - [RedisHoneyPot](https://github.com/cypwnpwnsocute/RedisHoneyPot) - High Interaction Honeypot Solution for Redis protocol.
 
 - Web honeypots
-  
+
+  - [Krawl](https://github.com/BlessedRebuS/Krawl) - Lightweight deception server and anti‑crawler that deploys realistic fake web applications with low‑hanging vulnerabilities and randomly generated decoy data.
   - [Cloud Active Defense](https://github.com/SAP/cloud-active-defense?tab=readme-ov-file) - Cloud active defense lets you deploy decoys right into your cloud applications, putting adversaries into a dilemma: to hack or not to hack?
   - [Express honeypot](https://github.com/christophe77/express-honeypot) - RFI & LFI honeypot using nodeJS and express.
   - [EoHoneypotBundle](https://github.com/eymengunay/EoHoneypotBundle) - Honeypot type for Symfony2 forms.


### PR DESCRIPTION
@paralax 

Add Krawl - a lightweight deception server and anti‑crawler that deploys realistic fake web applications with low‑hanging vulnerabilities and randomly generated decoy data.

[https://github.com/BlessedRebuS/Krawl](https://github.com/BlessedRebuS/Krawl)