### PR TITLE
Add nginx-honeypot

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Discover more awesome lists at [sindresorhus/awesome](https://github.com/sindres
   - [honeyhttpd](https://github.com/bocajspear1/honeyhttpd) - Python-based web server honeypot builder.
   - [honeyup](https://github.com/LogoiLab/honeyup) - An uploader honeypot designed to look like poor website security.
   - [modpot](https://github.com/referefref/modpot) - Modpot is a modular web application honeypot framework and management application written in Golang and making use of gin framework.
+  - [nginx-honeypot](https://github.com/GetPageSpeed/nginx-honeypot) - A simple honeypot based on NGINX configuration that logs and blocks bots scanning for vulnerabilities.
   - [owa-honeypot](https://github.com/joda32/owa-honeypot) - A basic flask based Outlook Web Honey pot.
   - [phpmyadmin_honeypot](https://github.com/gfoss/phpmyadmin_honeypot) - Simple and effective phpMyAdmin honeypot.
   - [shockpot](https://github.com/threatstream/shockpot) - WebApp Honeypot for detecting Shell Shock exploit attempts.


### PR DESCRIPTION
Added [nginx-honeypot](https://github.com/GetPageSpeed/nginx-honeypot) to the Web honeypots section.

A simple honeypot based on NGINX configuration that logs and blocks bots scanning for vulnerabilities.

- GitHub: https://github.com/GetPageSpeed/nginx-honeypot