### PR TITLE
Add Tracebit Free CanaryTokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,8 @@ Discover more awesome lists at [sindresorhus/awesome](https://github.com/sindres
   - [Honeyλ (HoneyLambda)](https://github.com/0x4D31/honeylambda) - Simple, serverless application designed to create and monitor URL honeytokens, on top of AWS Lambda and Amazon API Gateway.
   - [dcept](https://github.com/secureworks/dcept) - Tool for deploying and detecting use of Active Directory honeytokens.
   - [honeyku](https://github.com/0x4D31/honeyku) - Heroku-based web honeypot that can be used to create and monitor fake HTTP endpoints (i.e. honeytokens).
-
+  - [Tracebit Community Edition](https://community.tracebit.com) - online free canary tokens (AWS, SSH, Email, Web)
+    
 ## Honeyd Tools
 
 - Honeyd plugin


### PR DESCRIPTION
Adds a link to Tracebit Community Edition - free canary tokens

Full disclosure - I work at Tracebit