### PR TITLE
Add SSH-Radar - real-time SSH failed login visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ Discover more awesome lists at [sindresorhus/awesome](https://github.com/sindres
   - [Kippo-Graph](https://bruteforcelab.com/kippo-graph) - Full featured script to visualize statistics from a Kippo SSH honeypot.
   - [The Intelligent HoneyNet](https://github.com/jpyorre/IntelligentHoneyNet) - Create actionable information from honeypots.
   - [ovizart](https://github.com/oguzy/ovizart) - Visual analysis for network traffic.
+  - [SSH-Radar](https://github.com/antonsatt/ssh-radar) - Real-time monitoring and visualization of failed SSH login attempts with geolocation and Grafana dashboards.
 
 ## Guides
 


### PR DESCRIPTION
Adding my open-source project to the Data Tools > Visualization section (fits alongside tools like HoneyMap and Kippo-Graph for attack data viz):

- [SSH-Radar](https://github.com/antonsatt/ssh-radar) - Real-time monitoring and visualization of failed SSH login attempts with geolocation and Grafana dashboards.

It parses failed login logs, enriches with offline geolocation, and provides live stats/geomaps - useful for honeypot data analysis. Live demo: https://ssh-radar.antonsatt.com/

Follows guidelines (short desc, ends with period, no dupes). Thanks!