### PR TITLE
Add WebDecoy to WordPress honeypots

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Discover more awesome lists at [sindresorhus/awesome](https://github.com/sindres
     - [HonnyPotter](https://github.com/MartinIngesen/HonnyPotter) - WordPress login honeypot for collection and analysis of failed login attempts.
     - [HoneyPress](https://github.com/kungfuguapo/HoneyPress) - Python based WordPress honeypot in a Docker container.
     - [wp-smart-honeypot](https://github.com/freak3dot/wp-smart-honeypot) - WordPress plugin to reduce comment spam with a smarter honeypot.
+    - [WebDecoy](https://github.com/WebDecoy/wordpress-plugin) - Zero-configuration WordPress plugin with invisible honeypot fields, behavioral analysis, and SHA-256 proof-of-work challenges to detect bots, headless browsers, and automation frameworks.
     - [wordpot](https://github.com/gbrindisi/wordpot) - WordPress Honeypot.
   - [Python-Honeypot](https://github.com/OWASP/Python-Honeypot) - OWASP Honeypot, Automated Deception Framework.
 


### PR DESCRIPTION
Adds WebDecoy Bot Detection to the WordPress honeypots section. WebDecoy is a 
zero-configuration WordPress plugin that functions as an inline honeypot, detecting 
bots through invisible honeypot fields, behavioral analysis, headless browser 
detection, and SHA-256 proof-of-work challenges — without disrupting legitimate users.

- GitHub: https://github.com/WebDecoy/wordpress-plugin
- License: GPL-2.0

## Disclosure
I am the maintainer of WebDecoy.