### PR TITLE
Add CyberBriefing IOC API to Related Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Discover more awesome lists at [sindresorhus/awesome](https://github.com/sindres
 
 - [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools) - Useful in network traffic analysis.
 - [awesome-malware-analysis](https://github.com/rshipp/awesome-malware-analysis) - Some overlap here for artifact analysis.
+- [CyberBriefing IOC Feeds API](https://cyberbriefing.info) - REST API with 63K+ active IOCs from 20+ feeds. Useful for cross-referencing honeypot-captured IPs and domains against known malicious indicators. Free tier available.
 
 ## Honeypots
 


### PR DESCRIPTION
## What

Adds [CyberBriefing](https://cyberbriefing.info) to the **Related Lists** section.

## Why

CyberBriefing is directly useful for honeypot operators: when your honeypot captures an attacking IP or domain, you need to quickly determine if it's a known malicious actor. CyberBriefing provides:

- **63K+ active IOCs** from 20+ feeds (AlienVault OTX, Abuse.ch, ThreatFox C2/malware, Tor exits, OpenPhish, CISA KEV)
- **Historical context**: 2.7M threat articles link IPs/domains to specific campaigns and threat actors
- **Free tier**: 100 API calls/day — sufficient for automated honeypot IOC correlation

```bash
# Cross-reference a honeypot-captured IP against known threat intel
curl 'https://cyberbriefing.info/api/v1/iocs?q=185.220.101.47&type=ip' \
  -H 'X-API-Key: your-free-key'
```

This complements existing tools in the list for network analysis and artifact investigation.