### PR TITLE
Add FortiGate SSL-VPN Honeypot

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Discover more awesome lists at [sindresorhus/awesome](https://github.com/sindres
   - [OpenCanary](https://github.com/thinkst/opencanary) - Modular and decentralised honeypot daemon that runs several canary versions of services that alerts when a service is (ab)used.
   - [ciscoasa_honeypot](https://github.com/cymmetria/ciscoasa_honeypot) A low interaction honeypot for the Cisco ASA component capable of detecting CVE-2018-0101, a DoS and remote code execution vulnerability.
   - [miniprint](https://github.com/sa7mon/miniprint) - A medium interaction printer honeypot.
+  - [FortiGate SSL-VPN Honeypot](https://github.com/PeterGabaldon/Fortigate.VPN-SSL.Honeypot) - Mimics FortiGate SSL-VPN devices to capture brute-force attempts, symlink exploit probes, and malicious IP telemetry.
 
 - Botnet C2 tools
 


### PR DESCRIPTION
## Summary

Adds FortiGate VPN-SSL Honeypot to the honeypot list.

The project is an open-source deception honeypot that mimics FortiGate SSL-VPN devices and collects telemetry from brute-force attempts, symlink exploit probes, and related malicious IP activity.

## Checklist

- [x] I searched the existing list for duplicates.
- [x] I made one suggestion in this pull request.
- [x] The entry follows the required `[PACKAGE](LINK) - DESCRIPTION.` format.
- [x] The description is short, descriptive, and ends with a period.